### PR TITLE
lint

### DIFF
--- a/skeleton/manifests/params.pp.erb
+++ b/skeleton/manifests/params.pp.erb
@@ -1,5 +1,5 @@
 class <%= metadata.name %>::params {
-  
+
   case $::osfamily
   {
     'redhat':


### PR DESCRIPTION
[jprats@croscat eyp-pureftpd]$ rake lint
manifests/params.pp - ERROR: trailing whitespace found on line 2
rake aborted!

Tasks: TOP => lint
(See full trace by running task with --trace)
[jprats@croscat eyp-pureftpd]$ rake validate
